### PR TITLE
Replace Material Theme reference with Yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Depending on your platform it is located in the following folders:
   - <img src="https://developer.apple.com/favicon.ico" width=16 height=16/> **macOs** `~/.vscode/extensions`
   - <img src="https://www.microsoft.com/favicon.ico" width=16 height=16/> **Windows** `%USERPROFILE%\.vscode\extensions`
 
-Clone the Material Theme repository as `gamunu.vscode-yarn`:
+Clone the VSCode Yarn repository as `gamunu.vscode-yarn`:
 
 ```shell
 git clone git@github.com:gamunu/vscode-yarn.git gamunu.vscode-yarn


### PR DESCRIPTION
Just a minor typo:

> GitHub Repository Clone ↑
> ...
Clone the **Material Theme** repository as gamunu.vscode-yarn:

(emphasis mine)