### PR TITLE
Add option to change the default start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,15 @@ It has different behaviors on Unix or Windows.
    - yarn run build
    - yarn run test
    - yarn run start
+- `yarn.startScript` will change the default start script for example to `dev`
 
 ##### Example
 ```javascript
 {
   "yarn.runInTerminal": false,
   "yarn.dontHideOutputOnSuccess": false
-  "yarn.packageJson": "src/package.json"
+  "yarn.packageJson": "src/package.json",
+  "yarn.startScript": "dev"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -197,6 +197,10 @@
           "scope": "resource",
           "default": false,
           "description": "Enable yarn commands in the macOS touchbar."
+        },
+        "yarn.startScript": {
+          "type": "string",
+          "description": "Default start script to run (instead of start)"
         }
       }
     }

--- a/src/run.ts
+++ b/src/run.ts
@@ -3,6 +3,7 @@ import * as Fs from 'fs';
 import { workspace as Workspace, window as Window, QuickPickItem } from 'vscode';
 import * as Messages from './messages';
 import { runCommand } from './run-command';
+import { startScript } from './utils';
 
 let lastScript: string;
 
@@ -42,14 +43,15 @@ export function yarnStart() {
 	if (!scripts) {
 		return;
 	}
+	const startScriptName = startScript();
 
-	if (!scripts.start) {
+	if (!scripts[startScriptName]) {
 		Messages.noStartScript();
 		return;
 	}
 
-	lastScript = 'start';
-	runCommand(['run', 'start']);
+	lastScript = startScriptName;
+	runCommand(['run', startScriptName]);
 }
 
 export function yarnBuild() {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,6 +46,10 @@ export function getYarnBin() {
 	return Workspace.getConfiguration('yarn')['bin'] || 'yarn';
 }
 
+export function startScript() {
+	return Workspace.getConfiguration('yarn')['startScript'] || 'start';
+}
+
 export function dontHideOutputOnSuccess() {
 	return Workspace.getConfiguration('yarn')['dontHideOutputOnSuccess'];
 }


### PR DESCRIPTION
Added a new configurable option `startScript`, that's loaded in the utils with the default value `start` and used in the `yarnStart`.
Mainly did this because on the (Macbook's) Touch bar there's only a `start` button.
I could've made that changeable, but maybe there are more features a dev is using around the default start behaviour, so I think it's better to change that.